### PR TITLE
Change celery broker Redis -> RabbitMQ

### DIFF
--- a/.envs/.local/.django
+++ b/.envs/.local/.django
@@ -9,6 +9,7 @@ REDIS_URL=redis://redis:6379/0
 
 # Celery
 # ------------------------------------------------------------------------------
+RABBITMQ_URL=amqp://rabbitmq:5672
 
 # Flower
 CELERY_FLOWER_USER=CHANGEME

--- a/RABBITMQ_NOTES.md
+++ b/RABBITMQ_NOTES.md
@@ -1,0 +1,23 @@
+# LZ Celery Restart Tasks Automatically
+
+## First attempt
+
+At first it appeared that turning on [CELERY_TASK_ACKS_LATE](https://docs.celeryproject.org/en/latest/userguide/configuration.html#task-acks-late) and [CELERY_TASK_REJECT_ON_WORKER_LOST](https://docs.celeryproject.org/en/latest/userguide/configuration.html#task-reject-on-worker-lost) should do the trick. `CELERY_TASK_ACKS_LATE` means messages aren't acknowledged by workers until the job actually terminates, and `CELERY_TASK_REJECT_ON_WORKER_LOST` ensures that when a worker is killed with SIGKILL or SIGINT that the task will be rejected and re-queued. 
+
+Unfortunately, what seems to happen in practice is that when you kill celery (and all docker services), when they come back up, those unacknowledged messages never get sent back out to workers. This seems to be a known issue with no fix other than "use rabbitmq": 
+
+https://github.com/celery/celery/issues/3541
+https://github.com/celery/celery/issues/4984
+https://github.com/celery/celery/issues/5106
+
+There is possibly one fix, but it didn't work for me, and could result in unwanted behavior - decreasing `visibility_timeout` for redis broker: 
+
+https://stackoverflow.com/questions/41577723/if-celery-worker-dies-hard-does-job-get-retried
+
+Unfortunately, if `task_acks_late` is enabled, it means workers do not ack messages until after the work completes. But if the work doesn't complete within visibility timeout, it will be sent out again. That seems like a Bad Thing ™. 
+
+## Second attempt
+
+Trying switching to RabbitMQ to see if this solves the issue. RabbitMQ seems to be the preferred and default broker for celery. One potentially gotcha to be aware of is that the rabbitmq-server apparently does not like to be killed forcefully, which is exactly what happens if it does not shut down within the default 10 second timeout that docker-compose gives services to shut down. 
+
+After a very quick stab at this, it also does not seem to work.

--- a/compose/production/django/entrypoint
+++ b/compose/production/django/entrypoint
@@ -6,7 +6,7 @@ set -o nounset
 
 
 # N.B. If only .env files supported variable expansion...
-export CELERY_BROKER_URL="${REDIS_URL}"
+export CELERY_BROKER_URL="${RABBITMQ_URL}"
 
 if [ -z "${POSTGRES_USER}" ]; then
     base_postgres_image_default_user='postgres'

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -70,6 +70,15 @@ INSTALLED_APPS += ['django_extensions']  # noqa F405
 CELERY_TASK_ALWAYS_EAGER = False
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-eager-propagates
 CELERY_TASK_EAGER_PROPAGATES = True
+# http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-task_acks_late
+# This causes messages from worker tasks to be received only after the task has completed, not right
+# before it executes. This means your tasks MUST be idempotent (i.e. no side effects or issues from
+# running the task multiple times). Redis should also be set to persist data across reboots using
+# the appendonly log so that no data is lost at all when it shuts down.
+CELERY_TASK_ACKS_LATE = True
+# http://docs.celeryproject.org/en/latest/userguide/configuration.html#task-reject-on-worker-lost
+# This prevents the task from being lost simply because the worker was killed or terminated
+CELERY_TASK_REJECT_ON_WORKER_LOST = True
 
 # Misc other configuration
 # ------------------------------------------------------------------------------

--- a/local.yml
+++ b/local.yml
@@ -3,6 +3,7 @@ version: '3'
 volumes:
   local_postgres_data: {}
   local_postgres_data_backups: {}
+  local_rabbitmq_data: {}
 
 services:
   django: &django
@@ -37,11 +38,16 @@ services:
   redis:
     image: redis:3.2
 
+  rabbitmq:
+    image: rabbitmq:3.8
+    volumes:
+      - local_postgres_data:/var/lib/rabbitmq
+
   celeryworker:
     <<: *django
     image: locuszoom_plotting_service_local_celeryworker
     depends_on:
-      - redis
+      - rabbitmq
       - postgres
 
     ports: []
@@ -51,7 +57,7 @@ services:
     <<: *django
     image: locuszoom_plotting_service_local_celerybeat
     depends_on:
-      - redis
+      - rabbitmq
       - postgres
 
     ports: []


### PR DESCRIPTION
# Purpose
We would like to make long running jobs more reliable and more resilient to system restarts (eg don't lose jobs that were interrupted by a deploy). We used the redis broker as suggested by the django cookiecutter template; other and perhaps better supported options exist.

This ticket exists to track one possible option, which will need to be tested thoroughly in our staging environment.

# Proposal/ rationale
We are currently using Redis as our task broker for celery. We have encountered some problems.

Very long ingest jobs (large files) sometimes fail; it's possible that redis may have some default configuration options that cause keys to expire before the job is done (unfortunately, the relevant sentry issue expired before this ticket could be created)

# Further reading
- Warning about message loops: if `task_reject_on_worker_lost` is used, we must be sure to understand the most common reasons for failures that we previously glossed over. (including stress testing very large files, or other things that could kill a worker process due to eg resource limits)
http://docs.celeryproject.org/en/master/userguide/configuration.html#task-reject-on-worker-lost
- Redis docs: https://docs.celeryproject.org/en/latest/getting-started/brokers/redis.html
- Proposal to deprecate Redis as a broker support. [Rejected]: `https://github.com/celery/celery/issues/3274`